### PR TITLE
[wip] 663 integrations disabled env var

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -310,25 +310,26 @@ tracer.use('pg', {
 
 Options can be configured as a parameter to the [init()](./interfaces/tracer.html#init) method or as environment variables.
 
-| Config         | Environment Variable           | Default     | Description |
-| -------------- | ------------------------------ | ----------- | ----------- |
-| enabled        | `DD_TRACE_ENABLED`             | `true`      | Whether to enable the tracer. |
-| debug          | `DD_TRACE_DEBUG`               | `false`     | Enable debug logging in the tracer. |
-| service        | `DD_SERVICE_NAME`              | -           | The service name to be used for this program. |
-| url            | `DD_TRACE_AGENT_URL`           | -           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
-| hostname       | `DD_TRACE_AGENT_HOSTNAME`      | `localhost` | The address of the agent that the tracer will submit to. |
-| port           | `DD_TRACE_AGENT_PORT`          | `8126`      | The port of the trace agent that the tracer will submit to. |
-| dogstatsd.port | `DD_DOGSTATSD_PORT`            | `8125`      | The port of the Dogstatsd agent that metrics will be submitted to. |
-| env            | `DD_ENV`                       | -           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
-| logInjection   | `DD_LOGS_INJECTION`            | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
-| tags           | -                              | `{}`        | Set global tags that should be applied to all spans. |
-| sampleRate     | -                              | `1`         | Percentage of spans to sample as a float between 0 and 1. |
-| flushInterval  | -                              | `2000`      | Interval in milliseconds at which the tracer will submit traces to the agent. |
-| runtimeMetrics | `DD_RUNTIME_METRICS_ENABLED`   | `false`     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
-| reportHostname | `DD_TRACE_REPORT_HOSTNAME`     | `false`     | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
-| experimental   | -                              | `{}`        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
-| plugins        | -                              | `true`      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
-| clientToken    | `DD_CLIENT_TOKEN`              | -           | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
+| Config               | Environment Variable           | Default     | Description |
+| -------------------- | ------------------------------ | ----------- | ----------- |
+| enabled              | `DD_TRACE_ENABLED`             | `true`      | Whether to enable the tracer. |
+| debug                | `DD_TRACE_DEBUG`               | `false`     | Enable debug logging in the tracer. |
+| service              | `DD_SERVICE_NAME`              | -           | The service name to be used for this program. |
+| url                  | `DD_TRACE_AGENT_URL`           | -           | The url of the trace agent that the tracer will submit to. Takes priority over hostname and port, if set. |
+| hostname             | `DD_TRACE_AGENT_HOSTNAME`      | `localhost` | The address of the agent that the tracer will submit to. |
+| port                 | `DD_TRACE_AGENT_PORT`          | `8126`      | The port of the trace agent that the tracer will submit to. |
+| dogstatsd.port       | `DD_DOGSTATSD_PORT`            | `8125`      | The port of the Dogstatsd agent that metrics will be submitted to. |
+| env                  | `DD_ENV`                       | -           | Set an application’s environment e.g. `prod`, `pre-prod`, `stage`. |
+| logInjection         | `DD_LOGS_INJECTION`            | `false`     | Enable automatic injection of trace IDs in logs for supported logging libraries. |
+| tags                 | -                              | `{}`        | Set global tags that should be applied to all spans. |
+| sampleRate           | -                              | `1`         | Percentage of spans to sample as a float between 0 and 1. |
+| flushInterval        | -                              | `2000`      | Interval in milliseconds at which the tracer will submit traces to the agent. |
+| runtimeMetrics       | `DD_RUNTIME_METRICS_ENABLED`   | `false`     | Whether to enable capturing runtime metrics. Port 8125 (or configured with `dogstatsd.port`) must be opened on the agent for UDP. |
+| reportHostname       | `DD_TRACE_REPORT_HOSTNAME`     | `false`     | Whether to report the system's hostname for each trace. When disabled, the hostname of the agent will be used instead. |
+| experimental         | -                              | `{}`        | Experimental features can be enabled all at once using boolean `true` or individually using key/value pairs. Please contact us to learn more about the available experimental features. |
+| plugins              | -                              | `true`      | Whether or not to enable automatic instrumentation of external libraries using the built-in plugins. |
+| clientToken          | `DD_CLIENT_TOKEN`              | -           | Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`. |
+| integrationsDisabled | `DD_INTEGRATIONS_DISABLED`     | `[]`        | Set an array of integration names to automatically disable when the tracer is initializated, e.g. `['express','http','dns']`. |
 
 <h3 id="custom-logging">Custom Logging</h3>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,7 @@ export declare interface TracerOptions {
   reportHostname?: boolean
 
   /**
-   * List of integrations to disable when the tracer is initialized e.g. express,hapi,http,dns
+   * An array of integrations to automatically disable when the tracer is initialized e.g. [`express`,`hapi`,`dns`]
    * @default []
    */
   integrationsDisabled?: string[]

--- a/index.d.ts
+++ b/index.d.ts
@@ -289,6 +289,12 @@ export declare interface TracerOptions {
    * @default false
    */
   reportHostname?: boolean
+
+  /**
+   * List of integrations to disable when the tracer is initialized e.g. express,hapi,http,dns
+   * @default []
+   */
+  ddIntegrationsDisabled?: string[]
 }
 
 /** @hidden */

--- a/index.d.ts
+++ b/index.d.ts
@@ -294,7 +294,7 @@ export declare interface TracerOptions {
    * List of integrations to disable when the tracer is initialized e.g. express,hapi,http,dns
    * @default []
    */
-  ddIntegrationsDisabled?: string[]
+  integrationsDisabled?: string[]
   
   /**
    * Client token for browser tracing. Can be generated in the UI at `Integrations -> APIs`.

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -56,11 +56,11 @@ class Config {
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
-      peers: (options.experimental && options.experimental.peers) || [],
+      peers: (options.experimental && options.experimental.peers) || []
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
-    this.ddIntegrationsDisabled = coalesce(options.ddIntegrationsDisabled, platform.env('DD_INTEGRATIONS_DISABLED'), []
+    this.integrationsDisabled = coalesce(options.integrationsDisabled, platform.env('DD_INTEGRATIONS_DISABLED'), [])
     this.clientToken = clientToken
   }
 }

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -63,7 +63,7 @@ class Config {
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
     this.apiKey = apiKey
     this.appKey = appKey
-    this.ddIntegrationsDisabled = coalesce(options.ddIntegrationsDisabled, platform.env('DD_INTEGRATIONS_DISABLED'), null)
+    this.ddIntegrationsDisabled = coalesce(options.ddIntegrationsDisabled, platform.env('DD_INTEGRATIONS_DISABLED'), [])
   }
 }
 

--- a/packages/dd-trace/src/config.js
+++ b/packages/dd-trace/src/config.js
@@ -57,12 +57,13 @@ class Config {
     this.experimental = {
       b3: !(!options.experimental || !options.experimental.b3),
       exporter: options.experimental && options.experimental.exporter,
-      peers: (options.experimental && options.experimental.peers) || []
+      peers: (options.experimental && options.experimental.peers) || [],
     }
     this.reportHostname = String(reportHostname) === 'true'
     this.scope = platform.env('DD_CONTEXT_PROPAGATION') === 'false' ? scopes.NOOP : scope
     this.apiKey = apiKey
     this.appKey = appKey
+    this.ddIntegrationsDisabled = coalesce(options.ddIntegrationsDisabled, platform.env('DD_INTEGRATIONS_DISABLED'), null)
   }
 }
 

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -46,7 +46,7 @@ class Instrumenter {
           if (!config.integrationsDisabled || config.integrationsDisabled.indexOf(name) === -1) {
             this._set(plugins[name], { name, config: {} })
           } else {
-            log.debug(`configuration disabled via env var named "${name}".`)
+            log.debug(`configuration disabled via configuration option, named "${name}".`)
           }
         })
     }

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -28,7 +28,7 @@ class Instrumenter {
     try {
       this._set(plugins[name.toLowerCase()], { name, config })
     } catch (e) {
-      log.debug(`Could not find a plugin named "${name}" .`)
+      log.debug(`Could not find a plugin named "${name}".`)
     }
 
     if (this._enabled) {
@@ -43,12 +43,11 @@ class Instrumenter {
       Object.keys(plugins)
         .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
-          if(!config.ddIntegrationsDisabled || config.ddIntegrationsDisabled.indexOf(name) === -1) {
+          if (!config.integrationsDisabled || config.integrationsDisabled.indexOf(name) === -1) {
             this._set(plugins[name], { name, config: {} })
           } else {
             log.debug(`configuration disabled via env var named "${name}".`)
           }
-          
         })
     }
 

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -43,7 +43,12 @@ class Instrumenter {
       Object.keys(plugins)
         .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
-          this._set(plugins[name], { name, config: {} })
+          if(!config.ddIntegrationsDisabled && config.ddIntegrationsDisabled.indexOf(name) === -1) {
+            this._set(plugins[name], { name, config: {} })
+          } else {
+            log.debug(`configuration disabled via env var named "${name}".``)
+          }
+          
         })
     }
 

--- a/packages/dd-trace/src/instrumenter.js
+++ b/packages/dd-trace/src/instrumenter.js
@@ -28,7 +28,7 @@ class Instrumenter {
     try {
       this._set(plugins[name.toLowerCase()], { name, config })
     } catch (e) {
-      log.debug(`Could not find a plugin named "${name}".`)
+      log.debug(`Could not find a plugin named "${name}" .`)
     }
 
     if (this._enabled) {
@@ -43,10 +43,10 @@ class Instrumenter {
       Object.keys(plugins)
         .filter(name => !this._plugins.has(plugins[name]))
         .forEach(name => {
-          if(!config.ddIntegrationsDisabled && config.ddIntegrationsDisabled.indexOf(name) === -1) {
+          if(!config.ddIntegrationsDisabled || config.ddIntegrationsDisabled.indexOf(name) === -1) {
             this._set(plugins[name], { name, config: {} })
           } else {
-            log.debug(`configuration disabled via env var named "${name}".``)
+            log.debug(`configuration disabled via env var named "${name}".`)
           }
           
         })

--- a/packages/dd-trace/test/config.spec.js
+++ b/packages/dd-trace/test/config.spec.js
@@ -31,6 +31,7 @@ describe('Config', () => {
     expect(config).to.have.property('reportHostname', false)
     expect(config).to.have.property('scope', undefined)
     expect(config).to.have.property('clientToken', undefined)
+    expect(config).to.have.deep.property('integrationsDisabled', [])
     expect(config).to.have.nested.property('experimental.b3', false)
   })
 
@@ -92,6 +93,7 @@ describe('Config', () => {
     const tags = {
       'foo': 'bar'
     }
+    const mockDisabledIntegrations = ['express']
     const config = new Config('test', {
       enabled: false,
       debug: true,
@@ -113,6 +115,7 @@ describe('Config', () => {
       plugins: false,
       scope: 'noop',
       clientToken: '789',
+      integrationsDisabled: mockDisabledIntegrations,
       experimental: {
         b3: true
       }
@@ -136,6 +139,7 @@ describe('Config', () => {
     expect(config).to.have.property('plugins', false)
     expect(config).to.have.property('scope', 'noop')
     expect(config).to.have.property('clientToken', '789')
+    expect(config).to.have.property('integrationsDisabled', mockDisabledIntegrations)
     expect(config).to.have.deep.property('tags', {
       'foo': 'bar'
     })

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -98,7 +98,7 @@ describe('Instrumenter', () => {
         const express = require('express-mock')
 
         expect(integrations.express.patch).to.have.been.calledWith(express, 'tracer', config)
-      })
+      })      
 
       it('should default to an empty plugin configuration', () => {
         instrumenter.use('express-mock')
@@ -196,7 +196,7 @@ describe('Instrumenter', () => {
         require('other')
 
         expect(integrations.other.patch).to.have.been.called
-      })
+      })     
     })
 
     describe('patch', () => {
@@ -352,4 +352,28 @@ describe('Instrumenter', () => {
       })
     })
   })
+  
+  describe('with plugins disabled via configuration option', () => {
+    describe('enable', () => {
+      it('should not patch plugins disabled from configuration option', () => {
+        const config_disable = { foo: 'bar', ddIntegrationsDisabled: ['express-mock'] }
+        instrumenter.enable(config_disable)
+
+        const express = require('express-mock')
+
+        expect(integrations.express.patch).to.not.have.been.called
+      }) 
+
+      it('should patch plugins not disabled from configuration option', () => {
+        const config_empty = {}
+        const config_no_disable = { foo: 'bar', ddIntegrationsDisabled: [] }
+        instrumenter.enable(config_no_disable)
+
+        const express = require('express-mock')
+
+        expect(integrations.express.patch).to.have.been.calledWith(express, 'tracer', config_empty)
+      }) 
+    })
+  })
+
 })

--- a/packages/dd-trace/test/instrumenter.spec.js
+++ b/packages/dd-trace/test/instrumenter.spec.js
@@ -98,7 +98,7 @@ describe('Instrumenter', () => {
         const express = require('express-mock')
 
         expect(integrations.express.patch).to.have.been.calledWith(express, 'tracer', config)
-      })      
+      })
 
       it('should default to an empty plugin configuration', () => {
         instrumenter.use('express-mock')
@@ -196,7 +196,7 @@ describe('Instrumenter', () => {
         require('other')
 
         expect(integrations.other.patch).to.have.been.called
-      })     
+      })
     })
 
     describe('patch', () => {
@@ -352,28 +352,27 @@ describe('Instrumenter', () => {
       })
     })
   })
-  
+
   describe('with plugins disabled via configuration option', () => {
     describe('enable', () => {
       it('should not patch plugins disabled from configuration option', () => {
-        const config_disable = { foo: 'bar', ddIntegrationsDisabled: ['express-mock'] }
-        instrumenter.enable(config_disable)
+        const configDisabled = { foo: 'bar', integrationsDisabled: ['express-mock'] }
+        instrumenter.enable(configDisabled)
 
-        const express = require('express-mock')
+        require('express-mock')
 
         expect(integrations.express.patch).to.not.have.been.called
-      }) 
+      })
 
       it('should patch plugins not disabled from configuration option', () => {
-        const config_empty = {}
-        const config_no_disable = { foo: 'bar', ddIntegrationsDisabled: [] }
-        instrumenter.enable(config_no_disable)
+        const configDefault = {}
+        const configNotDisabled = { foo: 'bar', integrationsDisabled: [] }
+        instrumenter.enable(configNotDisabled)
 
         const express = require('express-mock')
 
-        expect(integrations.express.patch).to.have.been.calledWith(express, 'tracer', config_empty)
-      }) 
+        expect(integrations.express.patch).to.have.been.calledWith(express, 'tracer', configDefault)
+      })
     })
   })
-
 })


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Addresses issue ([663](https://github.com/DataDog/dd-trace-js/issues/663) by adding a ddIntegrationsDisabled and DD_INTEGRATIONS_DISABLED environment variable.

WIP

### Motivation
<!-- What inspired you to submit this pull request? -->

### Plugin Checklist
<!-- Fill this section if adding or updating a plugin. Remove otherwise. -->

- [ ] Unit tests.
- [ ] TypeScript [definitions][1].
- [ ] TypeScript [tests][2].
- [ ] API [documentation][3].
- [ ] CircleCI [jobs/workflows][4].
- [ ] Plugin is [exported][5].

[1]: https://github.com/DataDog/dd-trace-js/blob/master/index.d.ts
[2]: https://github.com/DataDog/dd-trace-js/blob/master/docs/test.ts
[3]: https://github.com/DataDog/dd-trace-js/blob/master/docs/API.md
[4]: https://github.com/DataDog/dd-trace-js/blob/master/.circleci/config.yml
[5]: https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/plugins/index.js

### Additional Notes
<!-- Anything else we should know when reviewing? -->

wip